### PR TITLE
[back/feature] 일기, 업로드 이미지 엔티티에 final 타입 및 지연로딩 추가

### DIFF
--- a/server/src/main/java/com/exchangediary/diary/domain/entity/Diary.java
+++ b/server/src/main/java/com/exchangediary/diary/domain/entity/Diary.java
@@ -24,19 +24,19 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor(access = PROTECTED)
+@NoArgsConstructor(access = PROTECTED, force = true)
 @AllArgsConstructor(access = PRIVATE)
 public class Diary extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "diary_id")
     private Long id;
-    private String writer;
-    private String profileImage;
+    private final String writer;
+    private final String profileImage;
+    private final Integer index;
     private String content;
     @Enumerated(EnumType.STRING)
     private PublicationStatus status;
-    private Integer index;
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "upload_image_id")
     private UploadImage uploadImage;

--- a/server/src/main/java/com/exchangediary/diary/domain/entity/Diary.java
+++ b/server/src/main/java/com/exchangediary/diary/domain/entity/Diary.java
@@ -42,5 +42,5 @@ public class Diary extends BaseEntity {
     private UploadImage uploadImage;
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "image_id")
-    private StaticImage staticImage;
+    private StaticImage moodImage;
 }

--- a/server/src/main/java/com/exchangediary/diary/domain/entity/Diary.java
+++ b/server/src/main/java/com/exchangediary/diary/domain/entity/Diary.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -36,10 +37,10 @@ public class Diary extends BaseEntity {
     @Enumerated(EnumType.STRING)
     private PublicationStatus status;
     private Integer index;
-    @OneToOne
+    @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "upload_image_id")
     private UploadImage uploadImage;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "image_id")
     private StaticImage staticImage;
 }

--- a/server/src/main/java/com/exchangediary/diary/domain/entity/UploadImage.java
+++ b/server/src/main/java/com/exchangediary/diary/domain/entity/UploadImage.java
@@ -19,14 +19,14 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @Builder
-@NoArgsConstructor(access = PROTECTED)
+@NoArgsConstructor(access = PROTECTED, force = true)
 @AllArgsConstructor(access = PRIVATE)
 public class UploadImage extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "upload_image_id")
     private Long id;
-    private String url;
+    private final String url;
     @Enumerated(EnumType.STRING)
     private PublicationStatus status;
 }


### PR DESCRIPTION
## Work Description
> 한 줄 요약 - 피드백 반영

- 초기화 이후 변경 가능성 없는 엔티티 필드에 대해서 `final` 추가
  - `final` 선언된 필드는 반드시 생성자에서 초기화되어야 하므로 기본생성자 어노테이션에 `force=true` 옵션 추가함. 
  - `force=true` 옵션이란, 모든 `final` 필드를 그 타입의 기본값으로 초기화됨. ex) 0 / `false` / `null`
https://github.com/exchangeDiary2024/exchange-diary/blob/14955719876b445d6246b8b2378e3b45b3565ccf/server/src/main/java/com/exchangediary/diary/domain/entity/Diary.java#L27-L29
- 연관관계(일대일, 다대일)에 지연 로딩 옵션 추가

## ISSUE
- closed #2

## To Reviewers
