### PR TITLE
스티커 목록 조회 API 개발

### DIFF
--- a/server/src/main/java/com/exchangediary/global/domain/StaticImageRepository.java
+++ b/server/src/main/java/com/exchangediary/global/domain/StaticImageRepository.java
@@ -1,0 +1,11 @@
+package com.exchangediary.global.domain;
+
+import com.exchangediary.global.domain.entity.StaticImage;
+import com.exchangediary.global.domain.entity.StaticImageType;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.List;
+
+public interface StaticImageRepository extends CrudRepository<StaticImage, Long> {
+    List<StaticImage> findAllByType(StaticImageType type);
+}

--- a/server/src/main/java/com/exchangediary/global/service/StaticImageQueryService.java
+++ b/server/src/main/java/com/exchangediary/global/service/StaticImageQueryService.java
@@ -1,0 +1,23 @@
+package com.exchangediary.global.service;
+
+import com.exchangediary.global.domain.StaticImageRepository;
+import com.exchangediary.global.domain.entity.StaticImage;
+import com.exchangediary.global.domain.entity.StaticImageType;
+import com.exchangediary.global.ui.dto.response.StickersResponse;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class StaticImageQueryService {
+    private final StaticImageRepository staticImageRepository;
+
+    public StaticImageQueryService(StaticImageRepository staticImageRepository) {
+        this.staticImageRepository = staticImageRepository;
+    }
+
+    public StickersResponse findStickers() {
+        List<StaticImage> stickers = staticImageRepository.findAllByType(StaticImageType.STICKER);
+        return StickersResponse.from(stickers);
+    }
+}

--- a/server/src/main/java/com/exchangediary/global/ui/StaticImageController.java
+++ b/server/src/main/java/com/exchangediary/global/ui/StaticImageController.java
@@ -1,0 +1,24 @@
+package com.exchangediary.global.ui;
+
+import com.exchangediary.global.service.StaticImageQueryService;
+import com.exchangediary.global.ui.dto.response.StickersResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class StaticImageController {
+    private final StaticImageQueryService staticImageQueryService;
+
+    public StaticImageController(StaticImageQueryService staticImageQueryService) {
+        this.staticImageQueryService = staticImageQueryService;
+    }
+
+    @GetMapping("stickers")
+    public ResponseEntity<StickersResponse> findStickers() {
+        StickersResponse stickers = staticImageQueryService.findStickers();
+        return ResponseEntity
+                .ok()
+                .body(stickers);
+    }
+}

--- a/server/src/main/java/com/exchangediary/global/ui/dto/response/StaticImageResponse.java
+++ b/server/src/main/java/com/exchangediary/global/ui/dto/response/StaticImageResponse.java
@@ -1,0 +1,17 @@
+package com.exchangediary.global.ui.dto.response;
+
+import com.exchangediary.global.domain.entity.StaticImage;
+import lombok.Builder;
+
+@Builder
+public record StaticImageResponse(
+        long id,
+        String imageUrl
+) {
+    public static StaticImageResponse from(StaticImage staticImage) {
+        return StaticImageResponse.builder()
+                .id(staticImage.getId())
+                .imageUrl(staticImage.getUrl())
+                .build();
+    }
+}

--- a/server/src/main/java/com/exchangediary/global/ui/dto/response/StickersResponse.java
+++ b/server/src/main/java/com/exchangediary/global/ui/dto/response/StickersResponse.java
@@ -1,0 +1,20 @@
+package com.exchangediary.global.ui.dto.response;
+
+import com.exchangediary.global.domain.entity.StaticImage;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record StickersResponse(
+        List<StaticImageResponse> stickers
+) {
+    public static StickersResponse from(List<StaticImage> staticImages) {
+        List<StaticImageResponse> stickers = staticImages.stream()
+                .map(StaticImageResponse::from)
+                .toList();
+        return StickersResponse.builder()
+                .stickers(stickers)
+                .build();
+    }
+}


### PR DESCRIPTION
> ## Work Description

> 한 줄 요약 : 스티커 목록 조회 API 개발

- 타입을 조건으로 하는 `StaticImage` 리스트를 조회하는 메서드를 `StaticImageRepository`에 추가했습니다.
- `StaticImageResponse`, `StickersReponse` DTO를 생성하였고, 
엔티티 객체로부터의 생성을 하는 정적팩터리메서드 `from` 를 추가했습니다.
- 스티커 목록 조회를 하는 `StaticImageQueryService`와 `StaticImageController`를 구현했습니다.

## ISSUE
- closed #22


## Screenshot
<img width="582" alt="Screenshot 2024-09-14 at 5 39 55 PM" src="https://github.com/user-attachments/assets/e458cfad-1bc6-434f-a9e2-e3e49d20e4be">

<img width="441" alt="Screenshot 2024-09-14 at 5 40 14 PM" src="https://github.com/user-attachments/assets/2c5666ee-1dc6-4694-bcda-d8688173e8d3">

- 임의의 더미 데이터를 만들어서 테스트를 진행하였습니다.
- 추후 테스트 코드 작성할 예정입니다.


## To Reviewers
- 기분 목록 조회 API에서도 조건만 다르고, 같은 쿼리가 사용된다고 생각하여서 아래 메서드를 추가했습니다.
재사용성을 생각하여 다음과 같이 구현한 것인데, 다른 의견이 있다면 말씀해주세요!
https://github.com/exchangeDiary2024/exchange-diary/blob/dc5207d5711673c157fda665edfdf3f7a6478572/server/src/main/java/com/exchangediary/global/domain/StaticImageRepository.java#L9-L11
- 또한 기분 목록 조회 API가 스티커 목록 조회 API와 응답의 형식이 거의 비슷하여서, 
StaticImageResponse 객체를 함께 사용해도 좋을 것 같습니다.
