### PR TITLE
기분 목록 조회 API 개발

### DIFF
--- a/server/src/main/java/com/exchangediary/global/service/StaticImageQueryService.java
+++ b/server/src/main/java/com/exchangediary/global/service/StaticImageQueryService.java
@@ -3,6 +3,7 @@ package com.exchangediary.global.service;
 import com.exchangediary.global.domain.StaticImageRepository;
 import com.exchangediary.global.domain.entity.StaticImage;
 import com.exchangediary.global.domain.entity.StaticImageType;
+import com.exchangediary.global.ui.dto.response.MoodsResponse;
 import com.exchangediary.global.ui.dto.response.StickersResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -19,5 +20,10 @@ public class StaticImageQueryService {
     public StickersResponse findStickers() {
         List<StaticImage> stickers = staticImageRepository.findAllByType(StaticImageType.STICKER);
         return StickersResponse.from(stickers);
+    }
+
+    public MoodsResponse findMoods() {
+        List<StaticImage> moods = staticImageRepository.findAllByType(StaticImageType.MOOD);
+        return MoodsResponse.from(moods);
     }
 }

--- a/server/src/main/java/com/exchangediary/global/ui/StaticImageController.java
+++ b/server/src/main/java/com/exchangediary/global/ui/StaticImageController.java
@@ -4,6 +4,7 @@ import com.exchangediary.diary.domain.entity.UploadImage;
 import com.exchangediary.global.domain.entity.StaticImage;
 import com.exchangediary.global.service.ImageService;
 import com.exchangediary.global.service.StaticImageQueryService;
+import com.exchangediary.global.ui.dto.response.MoodsResponse;
 import com.exchangediary.global.ui.dto.response.StickersResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
@@ -28,6 +29,14 @@ public class StaticImageController {
         return ResponseEntity
                 .ok()
                 .body(stickers);
+    }
+
+    @GetMapping("moods")
+    public ResponseEntity<MoodsResponse> findMoods() {
+        MoodsResponse moods = staticImageQueryService.findMoods();
+        return ResponseEntity
+                .ok()
+                .body(moods);
     }
 
     @GetMapping("api/images/upload/{id}")

--- a/server/src/main/java/com/exchangediary/global/ui/dto/response/MoodsResponse.java
+++ b/server/src/main/java/com/exchangediary/global/ui/dto/response/MoodsResponse.java
@@ -1,2 +1,20 @@
-package com.exchangediary.global.ui.dto.response;public class MoodsResponse {
+package com.exchangediary.global.ui.dto.response;
+
+import com.exchangediary.global.domain.entity.StaticImage;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record MoodsResponse(
+        List<StaticImageResponse> moods
+) {
+    public static MoodsResponse from (List<StaticImage> images) {
+        List<StaticImageResponse> moods = images.stream()
+                .map(StaticImageResponse::from)
+                .toList();
+        return MoodsResponse.builder()
+                .moods(moods)
+                .build();
+    }
 }

--- a/server/src/main/java/com/exchangediary/global/ui/dto/response/MoodsResponse.java
+++ b/server/src/main/java/com/exchangediary/global/ui/dto/response/MoodsResponse.java
@@ -1,0 +1,2 @@
+package com.exchangediary.global.ui.dto.response;public class MoodsResponse {
+}


### PR DESCRIPTION
## Work Description
> 기분 목록 조회 API를 개발했습니다

- 팩토리메서드 네이밍컨벤션 학습
- dto 생성
- 컨트롤러 생성
- 서비스 생성

## ISSUE
- closed #39

## Screenshot
<img width="589" alt="image" src="https://github.com/user-attachments/assets/aa15f244-1df7-4bc7-98d6-0a4672477a3a">

## To Reviewers
예은님이 만들어주신 쿼리 사용해서 거의 유사한 형태로 작업했습니다.
지금 코드는 스티커 목록 조회와 완전히 동일한 출력을 하고 있어서 만들어주신 StaticImageResponse record를 사용했는데, 다음 mvp에서 그룹 기능이 추가되면 분리하게 될 것 같습니다.

## Reference
[도움이 되었거나, 참고했던 사이트(코드링크)](https://ibnahmadmohamed.medium.com/design-patterns-factory-method-naming-conventions-5e843b1cdbaf)
