### PR TITLE
기분목록조회 이미지url null로 나오는 문제 해결

### DIFF
--- a/server/src/main/java/com/exchangediary/global/service/ImageService.java
+++ b/server/src/main/java/com/exchangediary/global/service/ImageService.java
@@ -44,9 +44,9 @@ public class ImageService {
                 .status(status)
                 .build();
 
-        UploadImage save = uploadImageRepository.save(image);
-        save.generateImageUrl(UPLOAD_IMAGE_URL + save.getId());
-        return uploadImageRepository.save(save);
+        UploadImage savedImage = uploadImageRepository.save(image);
+        savedImage.generateImageUrl(UPLOAD_IMAGE_URL + savedImage.getId());
+        return uploadImageRepository.save(savedImage);
     }
 
     public Optional<UploadImage> getUploadImage(Long id) {

--- a/server/src/main/java/com/exchangediary/global/service/ImageService.java
+++ b/server/src/main/java/com/exchangediary/global/service/ImageService.java
@@ -19,8 +19,8 @@ import java.util.UUID;
 public class ImageService {
     private final StaticImageRepository staticImageRepository;
     private final UploadImageRepository uploadImageRepository;
-    private static final String STATICIMAGE_URL = "/api/images/static/";
-    private static final String UPLOADIMAGE_URL = "/api/images/upload/";
+    private static final String STATIC_IMAGE_URL = "/api/images/static/";
+    private static final String UPLOAD_IMAGE_URL = "/api/images/upload/";
 
     /**
      * 사용자가 올린 이미지 업로드
@@ -33,7 +33,7 @@ public class ImageService {
     public UploadImage saveUploadImage(MultipartFile file, PublicationStatus status) throws IOException {
         String extension = file.getOriginalFilename()
                 .substring(file.getOriginalFilename().lastIndexOf("."));
-        String newFilename = UPLOADIMAGE_URL + UUID.randomUUID().toString() + extension;
+        String newFilename = UPLOAD_IMAGE_URL + UUID.randomUUID().toString() + extension;
 
         UploadImage image = UploadImage.builder()
                 .contentType(file.getContentType())
@@ -43,7 +43,7 @@ public class ImageService {
                 .build();
 
         UploadImage save = uploadImageRepository.save(image);
-        save.generateImageUrl(UPLOADIMAGE_URL + save.getId());
+        save.generateImageUrl(UPLOAD_IMAGE_URL + save.getId());
         return uploadImageRepository.save(save);
     }
 
@@ -61,7 +61,7 @@ public class ImageService {
      */
     public StaticImage saveStaticImage(MultipartFile file, StaticImageType type) throws IOException {
         String extension = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf("."));
-        String newFilename = STATICIMAGE_URL + UUID.randomUUID().toString() + extension;
+        String newFilename = STATIC_IMAGE_URL + UUID.randomUUID().toString() + extension;
 
         StaticImage image = StaticImage.builder()
                 .contentType(file.getContentType())
@@ -70,9 +70,9 @@ public class ImageService {
                 .type(type)
                 .build();
 
-        StaticImage save = staticImageRepository.save(image);
-        save.generateImageUrl(STATICIMAGE_URL + save.getId());
-        return staticImageRepository.save(save);
+        StaticImage saveImage = staticImageRepository.save(image);
+        saveImage.generateImageUrl(STATIC_IMAGE_URL + saveImage.getId());
+        return staticImageRepository.save(saveImage);
     }
 
     public Optional<StaticImage> getStaticImage(Long id) {

--- a/server/src/main/java/com/exchangediary/global/service/ImageService.java
+++ b/server/src/main/java/com/exchangediary/global/service/ImageService.java
@@ -35,7 +35,12 @@ public class ImageService {
                 .substring(file.getOriginalFilename().lastIndexOf("."));
         String newFilename = UPLOADIMAGE_URL + UUID.randomUUID().toString() + extension;
 
-        UploadImage image = UploadImage.builder().contentType(file.getContentType()).filename(newFilename).image(file.getBytes()).status(status).build();
+        UploadImage image = UploadImage.builder()
+                .contentType(file.getContentType())
+                .filename(newFilename)
+                .image(file.getBytes())
+                .status(status)
+                .build();
 
         UploadImage save = uploadImageRepository.save(image);
         save.generateImageUrl(UPLOADIMAGE_URL + save.getId());

--- a/server/src/main/java/com/exchangediary/global/service/ImageService.java
+++ b/server/src/main/java/com/exchangediary/global/service/ImageService.java
@@ -70,9 +70,9 @@ public class ImageService {
                 .type(type)
                 .build();
 
-        StaticImage saveImage = staticImageRepository.save(image);
-        saveImage.generateImageUrl(STATIC_IMAGE_URL + saveImage.getId());
-        return staticImageRepository.save(saveImage);
+        StaticImage savedImage = staticImageRepository.save(image);
+        savedImage.generateImageUrl(STATIC_IMAGE_URL + savedImage.getId());
+        return staticImageRepository.save(savedImage);
     }
 
     public Optional<StaticImage> getStaticImage(Long id) {

--- a/server/src/main/java/com/exchangediary/global/service/ImageService.java
+++ b/server/src/main/java/com/exchangediary/global/service/ImageService.java
@@ -20,7 +20,9 @@ public class ImageService {
     private final StaticImageRepository staticImageRepository;
     private final UploadImageRepository uploadImageRepository;
     private static final String STATIC_IMAGE_URL = "/api/images/static/";
+    private static final String STATIC_IMAGE_NAME = "exchange-static-";
     private static final String UPLOAD_IMAGE_URL = "/api/images/upload/";
+    private static final String UPLOAD_IMAGE_NAME = "exchange-upload-";
 
     /**
      * 사용자가 올린 이미지 업로드
@@ -33,7 +35,7 @@ public class ImageService {
     public UploadImage saveUploadImage(MultipartFile file, PublicationStatus status) throws IOException {
         String extension = file.getOriginalFilename()
                 .substring(file.getOriginalFilename().lastIndexOf("."));
-        String newFilename = UPLOAD_IMAGE_URL + UUID.randomUUID().toString() + extension;
+        String newFilename = UPLOAD_IMAGE_NAME + UUID.randomUUID().toString() + extension;
 
         UploadImage image = UploadImage.builder()
                 .contentType(file.getContentType())
@@ -61,7 +63,7 @@ public class ImageService {
      */
     public StaticImage saveStaticImage(MultipartFile file, StaticImageType type) throws IOException {
         String extension = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf("."));
-        String newFilename = STATIC_IMAGE_URL + UUID.randomUUID().toString() + extension;
+        String newFilename = STATIC_IMAGE_NAME + UUID.randomUUID().toString() + extension;
 
         StaticImage image = StaticImage.builder()
                 .contentType(file.getContentType())

--- a/server/src/main/java/com/exchangediary/global/service/ImageService.java
+++ b/server/src/main/java/com/exchangediary/global/service/ImageService.java
@@ -31,7 +31,8 @@ public class ImageService {
      * @throws IOException
      */
     public UploadImage saveUploadImage(MultipartFile file, PublicationStatus status) throws IOException {
-        String extension = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf("."));
+        String extension = file.getOriginalFilename()
+                .substring(file.getOriginalFilename().lastIndexOf("."));
         String newFilename = UPLOADIMAGE_URL + UUID.randomUUID().toString() + extension;
 
         UploadImage image = UploadImage.builder().contentType(file.getContentType()).filename(newFilename).image(file.getBytes()).status(status).build();
@@ -57,7 +58,12 @@ public class ImageService {
         String extension = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf("."));
         String newFilename = STATICIMAGE_URL + UUID.randomUUID().toString() + extension;
 
-        StaticImage image = StaticImage.builder().contentType(file.getContentType()).filename(newFilename).image(file.getBytes()).type(type).build();
+        StaticImage image = StaticImage.builder()
+                .contentType(file.getContentType())
+                .filename(newFilename)
+                .image(file.getBytes())
+                .type(type)
+                .build();
 
         StaticImage save = staticImageRepository.save(image);
         save.generateImageUrl(STATICIMAGE_URL + save.getId());

--- a/server/src/main/java/com/exchangediary/global/service/ImageService.java
+++ b/server/src/main/java/com/exchangediary/global/service/ImageService.java
@@ -22,7 +22,8 @@ public class ImageService {
 
     /**
      * 사용자가 올린 이미지 업로드
-     * @param file 이미지 파일
+     *
+     * @param file   이미지 파일
      * @param status 발행 상태
      * @return
      * @throws IOException
@@ -45,12 +46,13 @@ public class ImageService {
         return save;
     }
 
-    public Optional<UploadImage> getUploadImage(Long id){
+    public Optional<UploadImage> getUploadImage(Long id) {
         return uploadImageRepository.findById(id);
     }
 
     /**
      * static 이미지 업로드
+     *
      * @param file 이미지 파일
      * @param type 이미지 종류
      * @return
@@ -60,7 +62,7 @@ public class ImageService {
             throws IOException {
         String extension = file.getOriginalFilename().substring(file.getOriginalFilename()
                 .lastIndexOf("."));
-        String newFilename = "/api/images/static/" + UUID.randomUUID().toString() + extension;;
+        String newFilename = "/api/images/static/" + UUID.randomUUID().toString() + extension;
 
         StaticImage image = StaticImage.builder()
                 .contentType(file.getContentType())
@@ -71,10 +73,10 @@ public class ImageService {
 
         StaticImage save = staticImageRepository.save(image);
         save.generateImageUrl("/api/images/static/" + save.getId());
-        return save;
+        return staticImageRepository.save(save);
     }
 
-    public Optional<StaticImage> getStaticImage(Long id){
+    public Optional<StaticImage> getStaticImage(Long id) {
         return staticImageRepository.findById(id);
     }
 }

--- a/server/src/main/java/com/exchangediary/global/service/ImageService.java
+++ b/server/src/main/java/com/exchangediary/global/service/ImageService.java
@@ -19,6 +19,8 @@ import java.util.UUID;
 public class ImageService {
     private final StaticImageRepository staticImageRepository;
     private final UploadImageRepository uploadImageRepository;
+    private static final String STATICIMAGE_URL = "/api/images/static/";
+    private static final String UPLOADIMAGE_URL = "/api/images/upload/";
 
     /**
      * 사용자가 올린 이미지 업로드
@@ -28,22 +30,15 @@ public class ImageService {
      * @return
      * @throws IOException
      */
-    public UploadImage saveUploadImage(MultipartFile file, PublicationStatus status)
-            throws IOException {
-        String extension = file.getOriginalFilename().substring(file.getOriginalFilename()
-                .lastIndexOf("."));
-        String newFilename = "/api/images/upload/" + UUID.randomUUID().toString() + extension;
+    public UploadImage saveUploadImage(MultipartFile file, PublicationStatus status) throws IOException {
+        String extension = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf("."));
+        String newFilename = UPLOADIMAGE_URL + UUID.randomUUID().toString() + extension;
 
-        UploadImage image = UploadImage.builder()
-                .contentType(file.getContentType())
-                .filename(newFilename)
-                .image(file.getBytes())
-                .status(status)
-                .build();
+        UploadImage image = UploadImage.builder().contentType(file.getContentType()).filename(newFilename).image(file.getBytes()).status(status).build();
 
         UploadImage save = uploadImageRepository.save(image);
-        save.generateImageUrl("/api/images/upload/" + save.getId());
-        return save;
+        save.generateImageUrl(UPLOADIMAGE_URL + save.getId());
+        return uploadImageRepository.save(save);
     }
 
     public Optional<UploadImage> getUploadImage(Long id) {
@@ -58,21 +53,14 @@ public class ImageService {
      * @return
      * @throws IOException
      */
-    public StaticImage saveStaticImage(MultipartFile file, StaticImageType type)
-            throws IOException {
-        String extension = file.getOriginalFilename().substring(file.getOriginalFilename()
-                .lastIndexOf("."));
-        String newFilename = "/api/images/static/" + UUID.randomUUID().toString() + extension;
+    public StaticImage saveStaticImage(MultipartFile file, StaticImageType type) throws IOException {
+        String extension = file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf("."));
+        String newFilename = STATICIMAGE_URL + UUID.randomUUID().toString() + extension;
 
-        StaticImage image = StaticImage.builder()
-                .contentType(file.getContentType())
-                .filename(newFilename)
-                .image(file.getBytes())
-                .type(type)
-                .build();
+        StaticImage image = StaticImage.builder().contentType(file.getContentType()).filename(newFilename).image(file.getBytes()).type(type).build();
 
         StaticImage save = staticImageRepository.save(image);
-        save.generateImageUrl("/api/images/static/" + save.getId());
+        save.generateImageUrl(STATICIMAGE_URL + save.getId());
         return staticImageRepository.save(save);
     }
 


### PR DESCRIPTION
## Work Description
> 기분목록조회 및 스티커목록조회 imageUrl이 null로 나오는 문제를 해결했습니다.

- StaticImage 저장 과정에서 url 설정 이후 save를 하지 않아서 url이 null로 나오는 문제를 해결했습니다.
- UploadImage 저장 과정에서 url 설정 이후 save를 하지 않아서 url이 null로 나오는 문제를 해결했습니다.
- 모든 url을 상수로 리팩토링했습니다.
- 파일명 저장 로직을 변경했습니다 (/제거)

## ISSUE
- closed #80


## Screenshot
- 해결 전
<img width="174" alt="image" src="https://github.com/user-attachments/assets/da0e01c8-3628-4951-9661-0529ba924abe">

- 해결 후
<img width="287" alt="image" src="https://github.com/user-attachments/assets/849f4c5b-afe7-47b5-bde2-463cfb3f432f">


## To Reviewers
검수를 꼼꼼히 하겠습니다😨


