### PR TITLE
sticker 엔티티 오류 해결

### DIFF
--- a/server/src/main/java/com/exchangediary/diary/domain/entity/Sticker.java
+++ b/server/src/main/java/com/exchangediary/diary/domain/entity/Sticker.java
@@ -28,7 +28,7 @@ public class Sticker extends BaseEntity {
     @Id
     @Column(name = "sticker_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long Id;
+    private Long id;
     private final Double coordX;
     private final Double coordY;
     private final Integer coordZ;

--- a/server/src/main/java/com/exchangediary/diary/domain/entity/Sticker.java
+++ b/server/src/main/java/com/exchangediary/diary/domain/entity/Sticker.java
@@ -53,6 +53,7 @@ public class Sticker extends BaseEntity {
                 .coordZ(coordZ)
                 .width(stickerRequest.width())
                 .height(stickerRequest.height())
+                .rotation(stickerRequest.rotation())
                 .diary(diary)
                 .staticImage(staticImage)
                 .build();


### PR DESCRIPTION
## Work Description
> 한 줄 요약 : sticker 엔티티 오류 해결


- sticker 엔티티 `id` 네이밍이 `Id`로 되어있어서 컨벤션에 맞게 변경했습니다.
- sticker 엔티티를 생성하는 정적팩터리메서드 `of()`에 `rotation` 필드 값을 설정하는 부분이 누락되어 추가했습니다.


## ISSUE
- closed #83


## Screenshot
- 통합 테스트 코드
```java
@Test
void 스티커_붙이기_성공() {
    StickerRequest stickerRequest = StickerRequest.builder()
            .coordX(1.0)
            .coordY(2.0)
            .width(1.0)
            .height(2.0)
            .rotation(90.0)
            .build();

    var response = RestAssured
            .given().log().all()
            .contentType(ContentType.JSON)
            .body(stickerRequest)
            .when().post("/diary/" + 1 + "/sticker/" + 1)
            .then().log().all()
            .statusCode(HttpStatus.CREATED.value())
            .extract();

    String location = response.header("location");
    assertThat(location).isEqualTo("/diary/" + 1);
    // TODO: Location으로 API 요청 후, 스티커 붙여졌는지 확인
    RestAssured
            .given().log().all()
            .when().get(location)
            .then().log().all()
            .statusCode(HttpStatus.OK.value());
}
```

- 문제 해결 전
<img width="1142" alt="Screenshot 2024-09-20 at 7 53 37 PM" src="https://github.com/user-attachments/assets/163960a8-2afb-4f74-b9a4-39475c8547d7">

- 문제 해결 후
<img width="444" alt="Screenshot 2024-09-20 at 8 07 12 PM" src="https://github.com/user-attachments/assets/f5a11b01-58ac-4b06-ba3e-5d75b07b4452">


